### PR TITLE
Fix test failing after bookkeeping.md file is removed.

### DIFF
--- a/test/fixtures/ruby/exercises/alpha/.meta/generator/test_template.erb
+++ b/test/fixtures/ruby/exercises/alpha/.meta/generator/test_template.erb
@@ -12,10 +12,4 @@ class <%= exercise_name_camel %>Test < Minitest::Test
   end
 
 <% end %>
-<%= IO.read(EXERCISM_RUBY_LIB + '/bookkeeping.md') %>
-
-  def test_bookkeeping
-    skip
-    assert_equal <%= version %>, BookKeeping::VERSION
-  end
 end

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -60,6 +60,7 @@ class AlphaTest < Minitest::Test
     # skip
     assert true
   end
+
 end
 TESTS_FILE
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]


### PR DESCRIPTION
The test should not have been using the production version of the
file.